### PR TITLE
Panza Web Server

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# Store API keys here
+API_KEYS=apikey1,apikey2,apikey3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "cmake",
     "packaging",
     "nltk",
+    "ollama",
     "llm-foundry@git+https://github.com/IST-DASLab/llm-foundry",
     "peft@git+https://github.com/IST-DASLab/peft-rosa.git@grad_quant_looser_versioning",
     "spops-sm-80"

--- a/scripts/run_ollama_services.sh
+++ b/scripts/run_ollama_services.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+source config.sh
+
+MODEL="custom"
+
+DEVICE="cuda:1"
+DTYPE="bf16"
+
+for ARGUMENT in "$@"
+do
+   KEY=$(echo $ARGUMENT | cut -f1 -d=)
+
+   KEY_LENGTH=${#KEY}
+   VALUE="${ARGUMENT:$KEY_LENGTH+1}"
+
+   export "$KEY"="$VALUE"
+done
+
+USE_RAG=$([ "${PANZA_DISABLE_RAG_INFERENCE}" = "1" ] && echo "" || echo "--use-rag")
+USE_4BIT_QUANT=$([ "${MODEL_PRECISION}" = "4bit" ] && echo "--load-in-4bit" || echo "")
+
+INFERENCE_SCRIPT=${PANZA_WORKSPACE}/src/panza/evaluation/ollama_service_inference.py
+python ${INFERENCE_SCRIPT} \
+    --model=${MODEL} \
+    --device=${DEVICE} \
+    --dtype=${DTYPE} \
+    --system-preamble=${PANZA_SYSTEM_PREAMBLE_PATH} \
+    --user-preamble=${PANZA_USER_PREAMBLE_PATH} \
+    --rag-preamble=${PANZA_RAG_PREAMBLE_PATH} \
+    --embedding-model=${PANZA_EMBEDDING_MODEL} \
+    --db-path=${PANZA_DATA_DIR} \
+    --index-name=${PANZA_USERNAME} \
+    --rag-relevance-threshold=${PANZA_RAG_RELEVANCE_THRESHOLD} \
+    ${USE_RAG} \
+    ${USE_4BIT_QUANT}

--- a/scripts/run_panza_ollama.sh
+++ b/scripts/run_panza_ollama.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+source config.sh
+
+MODEL=${PANZA_GENERATIVE_MODEL}  # Replace this with the checkpoint you want to use!
+
+for ARGUMENT in "$@"
+do
+   KEY=$(echo $ARGUMENT | cut -f1 -d=)
+
+   KEY_LENGTH=${#KEY}
+   VALUE="${ARGUMENT:$KEY_LENGTH+1}"
+
+   export "$KEY"="$VALUE"
+done
+
+USE_RAG=$([ "${PANZA_DISABLE_RAG_INFERENCE}" = "1" ] && echo "" || echo "--use-rag")
+USE_4BIT_QUANT=$([ "${MODEL_PRECISION}" = "4bit" ] && echo "--load-in-4bit" || echo "")
+
+INFERENCE_SCRIPT=${PANZA_WORKSPACE}/src/panza/evaluation/ollama_inference.py
+python ${INFERENCE_SCRIPT} \
+    --model=llama3.1 \
+    --system-preamble=${PANZA_SYSTEM_PREAMBLE_PATH} \
+    --user-preamble=${PANZA_USER_PREAMBLE_PATH} \
+    --rag-preamble=${PANZA_RAG_PREAMBLE_PATH} \
+    --embedding-model=${PANZA_EMBEDDING_MODEL} \
+    --db-path=${PANZA_DATA_DIR} \
+    --index-name=${PANZA_USERNAME} \
+    --rag-relevance-threshold=${PANZA_RAG_RELEVANCE_THRESHOLD} \
+    ${USE_RAG} \
+    ${USE_4BIT_QUANT}

--- a/scripts/run_services.sh
+++ b/scripts/run_services.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+source config.sh
+
+MODEL="../checkpoints/models/panza_seanyang711_llama3_bf16-bs8-rosa_wl16_d0.01_1grads_mean_squared_r8_loralr1e-5_alpha16-lr1e-5-epochs5-wu8-seed42-PREAMBLE-16296"
+
+DEVICE="cuda:1"
+DTYPE="bf16"
+
+for ARGUMENT in "$@"
+do
+   KEY=$(echo $ARGUMENT | cut -f1 -d=)
+
+   KEY_LENGTH=${#KEY}
+   VALUE="${ARGUMENT:$KEY_LENGTH+1}"
+
+   export "$KEY"="$VALUE"
+done
+
+USE_RAG=$([ "${PANZA_DISABLE_RAG_INFERENCE}" = "1" ] && echo "" || echo "--use-rag")
+USE_4BIT_QUANT=$([ "${MODEL_PRECISION}" = "4bit" ] && echo "--load-in-4bit" || echo "")
+
+INFERENCE_SCRIPT=${PANZA_WORKSPACE}/src/panza/evaluation/service_inference.py
+python ${INFERENCE_SCRIPT} \
+    --model=${MODEL} \
+    --device=${DEVICE} \
+    --dtype=${DTYPE} \
+    --system-preamble=${PANZA_SYSTEM_PREAMBLE_PATH} \
+    --user-preamble=${PANZA_USER_PREAMBLE_PATH} \
+    --rag-preamble=${PANZA_RAG_PREAMBLE_PATH} \
+    --embedding-model=${PANZA_EMBEDDING_MODEL} \
+    --db-path=${PANZA_DATA_DIR} \
+    --index-name=${PANZA_USERNAME} \
+    --rag-relevance-threshold=${PANZA_RAG_RELEVANCE_THRESHOLD} \
+    ${USE_RAG} \
+    ${USE_4BIT_QUANT}

--- a/src/panza/evaluation/ollama_inference.py
+++ b/src/panza/evaluation/ollama_inference.py
@@ -1,0 +1,83 @@
+import os
+import sys
+
+import ollama
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from panza.evaluation import base_inference
+from panza.utils import prompting, rag
+from panza.utils.documents import Email
+
+sys.path.pop(0)
+
+
+def get_response_stream(prompt: str, model: str):
+    stream = ollama.chat(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        stream=True,
+    )
+
+    return stream
+
+
+def print_response_stream(stream):
+    for chunk in stream:
+        print(chunk["message"]["content"], end="", flush=True)
+
+
+
+def main():
+    parser = base_inference.get_base_inference_args_parser()
+    args = parser.parse_args()
+
+    print("Running inference with args:", args)
+
+    if args.nthreads is not None:
+        torch.set_num_threads(args.nthreads)
+
+
+    if args.use_rag:
+        embeddings_model = rag.get_embeddings_model(args.embedding_model)
+        db = rag.load_vector_db_from_disk(args.db_path, args.index_name, embeddings_model)
+
+    system_preamble, user_preamble, rag_preamble, _ = prompting.load_all_preambles(
+        args.system_preamble, args.user_preamble, args.rag_preamble, args.thread_preamble
+    )
+
+    while True:
+        instruction = input("Enter another request  (or 'quit' to exit): ")
+
+        if instruction.lower() == "quit":
+            print("Exiting...")
+            break
+
+        relevant_emails = []
+        if args.use_rag:
+            assert db is not None, "RAG requires a database to be provided."
+            re = db._similarity_search_with_relevance_scores(instruction, k=args.rag_num_emails)
+            relevant_emails = [
+                Email.deserialize(r[0].metadata["serialized_email"])
+                for r in re
+                if r[1] >= args.rag_relevance_threshold
+            ]
+
+        prompt = prompting.create_prompt(
+            instruction,
+            system_preamble,
+            user_preamble,
+            rag_preamble,
+            relevant_emails,
+        )
+
+        print("Running with prompt:", prompt)
+
+        args.model = "llama3.1"
+        stream = get_response_stream(prompt, args.model)
+        print_response_stream(stream)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/panza/evaluation/ollama_service_inference.py
+++ b/src/panza/evaluation/ollama_service_inference.py
@@ -1,0 +1,77 @@
+import os
+import sys
+from typing import Annotated
+
+from fastapi import FastAPI, HTTPException, Header
+from fastapi.responses import StreamingResponse
+import uvicorn
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from dotenv import load_dotenv
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from panza.evaluation import base_inference
+from panza.utils import prompting
+from panza.evaluation import ollama_inference
+
+class Request(BaseModel):
+    text: str
+
+sys.path.pop(0)
+
+app = FastAPI()
+
+origins = [
+    "https://mail.google.com",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Load environment variables from the .env file
+load_dotenv()
+valid_api_keys = os.getenv("API_KEYS").split(",")
+
+parser = base_inference.get_base_inference_args_parser()
+args = parser.parse_args()
+
+print("Running inference with args:", args)
+
+system_preamble, user_preamble, rag_preamble, _ = prompting.load_all_preambles(
+    args.system_preamble, args.user_preamble, args.rag_preamble, args.thread_preamble
+)
+
+def predict(user_input):
+    relevant_emails = []
+    prompt = prompting.create_prompt(
+            user_input,
+            system_preamble,
+            user_preamble,
+            rag_preamble,
+            relevant_emails,
+        )
+    return ollama_inference.get_response_stream(prompt, args.model)
+
+def streamer(stream):
+    for chunk in stream:
+        yield chunk["message"]["content"]
+
+@app.options('/generate')
+def options():
+    return {"methods": ["POST"]}
+
+@app.post('/generate')
+def generate_text(request: Request, x_api_key: Annotated[str | None, Header()] = None):
+    if x_api_key not in valid_api_keys:
+        raise HTTPException(status_code=401, detail="Invalid API key.")
+    stream = predict(request.text)
+    return StreamingResponse(streamer(stream), media_type='text/event-stream')
+
+if __name__ == '__main__':
+    uvicorn.run(app, host='0.0.0.0', port=5001)

--- a/src/panza/evaluation/service_inference.py
+++ b/src/panza/evaluation/service_inference.py
@@ -1,40 +1,66 @@
 import os
 import sys
+from typing import Annotated
 
 import torch
-from flask import Flask, jsonify, request
-from flask_cors import CORS
+
+from fastapi import FastAPI, HTTPException, Header
+import uvicorn
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from dotenv import load_dotenv
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 from panza.evaluation import base_inference
 from panza.utils import prompting, rag
 
+class Request(BaseModel):
+    text: str
+
+class Response(BaseModel):
+    generated_text: str
+
 sys.path.pop(0)
 
-app = Flask(__name__)
-CORS(app)
+app = FastAPI()
+
+origins = [
+    "https://mail.google.com",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Load environment variables from the .env file
+load_dotenv()
+valid_api_keys = os.getenv("API_KEYS").split(",")
+
+parser = base_inference.get_base_inference_args_parser()
+args = parser.parse_args()
+
+print("Running inference with args:", args)
+
+if args.nthreads is not None:
+    torch.set_num_threads(args.nthreads)
+
+print("Loading model ", args.model)
+model, tokenizer = base_inference.load_model_and_tokenizer(args.model, args.device, args.dtype, load_in_4bit=args.load_in_4bit)
+
+if args.use_rag:
+    embeddings_model = rag.get_embeddings_model(args.embedding_model)
+    db = rag.load_vector_db_from_disk(args.db_path, args.index_name, embeddings_model)
+
+system_preamble, user_preamble, rag_preamble = prompting.load_all_preambles(
+    args.system_preamble, args.user_preamble, args.rag_preamble
+)
 
 def predict(user_input):
-    parser = base_inference.get_base_inference_args_parser()
-    args = parser.parse_args()
-
-    print("Running inference with args:", args)
-
-    if args.nthreads is not None:
-        torch.set_num_threads(args.nthreads)
-
-    print("Loading model ", args.model)
-    model, tokenizer = base_inference.load_model_and_tokenizer(args.model, args.device, args.dtype, load_in_4bit=args.load_in_4bit)
-
-    if args.use_rag:
-        embeddings_model = rag.get_embeddings_model(args.embedding_model)
-        db = rag.load_vector_db_from_disk(args.db_path, args.index_name, embeddings_model)
-
-    system_preamble, user_preamble, rag_preamble = prompting.load_all_preambles(
-        args.system_preamble, args.user_preamble, args.rag_preamble
-    )
-
     prompts, outputs = base_inference.run_inference(
         instructions=[user_input],
         model=model,
@@ -59,22 +85,17 @@ def predict(user_input):
 
     return outputs[0]
 
+@app.options('/generate')
+def options():
+    return {"methods": ["POST"]}
 
-@app.route('/generate', methods=['POST'])
-def generate_text():
-    if not isValidApiKey():
-        return jsonify({"error": "Invalid API Key"}), 401
-    data = request.get_json()
-    print(data)
-    print(data["text"])
-    output = predict(data["text"])
-    return jsonify(generated_text=output)
-
-def isValidApiKey():
-    api_key = request.headers.get('x-api-key')
-    valid_api_keys = os.getenv('API_KEYS').split(',')
-    return api_key in valid_api_keys
+@app.post('/generate')
+def generate_text(request: Request, x_api_key: Annotated[str | None, Header()] = None):
+    if x_api_key not in valid_api_keys:
+        raise HTTPException(status_code=401, detail="Invalid API key, must be one of: " + str(valid_api_keys))
+    generated_text = predict(request.text)
+    return {"generated_text": generated_text}
     
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    uvicorn.run(app, host='0.0.0.0', port=5000)

--- a/src/panza/evaluation/service_inference.py
+++ b/src/panza/evaluation/service_inference.py
@@ -62,18 +62,18 @@ def predict(user_input):
 
 @app.route('/generate', methods=['POST'])
 def generate_text():
-    checkApiKey()
+    if not isValidApiKey():
+        return jsonify({"error": "Invalid API Key"}), 401
     data = request.get_json()
     print(data)
     print(data["text"])
     output = predict(data["text"])
     return jsonify(generated_text=output)
 
-def checkApiKey():
+def isValidApiKey():
     api_key = request.headers.get('x-api-key')
     valid_api_keys = os.getenv('API_KEYS').split(',')
-    if api_key not in valid_api_keys:
-        os.abort(401)  # Unauthorized
+    return api_key in valid_api_keys
     
 
 if __name__ == '__main__':

--- a/src/panza/evaluation/service_inference.py
+++ b/src/panza/evaluation/service_inference.py
@@ -1,0 +1,73 @@
+import os
+import sys
+
+import torch
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+from panza.evaluation import base_inference
+from panza.utils import prompting, rag
+
+sys.path.pop(0)
+
+app = Flask(__name__)
+CORS(app)
+
+def predict(user_input):
+    parser = base_inference.get_base_inference_args_parser()
+    args = parser.parse_args()
+
+    print("Running inference with args:", args)
+
+    if args.nthreads is not None:
+        torch.set_num_threads(args.nthreads)
+
+    print("Loading model ", args.model)
+    model, tokenizer = base_inference.load_model_and_tokenizer(args.model, args.device, args.dtype, load_in_4bit=args.load_in_4bit)
+
+    if args.use_rag:
+        embeddings_model = rag.get_embeddings_model(args.embedding_model)
+        db = rag.load_vector_db_from_disk(args.db_path, args.index_name, embeddings_model)
+
+    system_preamble, user_preamble, rag_preamble = prompting.load_all_preambles(
+        args.system_preamble, args.user_preamble, args.rag_preamble
+    )
+
+    prompts, outputs = base_inference.run_inference(
+        instructions=[user_input],
+        model=model,
+        tokenizer=tokenizer,
+        system_preamble=system_preamble,
+        user_preamble=user_preamble,
+        rag_preamble=rag_preamble,
+        rag_relevance_threshold=args.rag_relevance_threshold,
+        rag_num_emails=args.rag_num_emails,
+        use_rag=args.use_rag,
+        db=db if args.use_rag else None,
+        max_new_tokens=args.max_new_tokens,
+        best=args.best,
+        temperature=args.temperature,
+        top_k=args.top_k,
+        top_p=args.top_p,
+        device=args.device,
+    )
+
+    print("Processed input:", prompts[0])
+    print("Generated email", outputs[0])
+
+    return outputs[0]
+
+
+@app.route('/generate', methods=['POST'])
+def generate_text():
+    data = request.get_json()
+    print(data)
+    print(data["text"])
+    output = predict(data["text"])
+    return jsonify(generated_text=output)
+
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0', port=5000)

--- a/src/panza/evaluation/service_inference.py
+++ b/src/panza/evaluation/service_inference.py
@@ -62,12 +62,19 @@ def predict(user_input):
 
 @app.route('/generate', methods=['POST'])
 def generate_text():
+    checkApiKey()
     data = request.get_json()
     print(data)
     print(data["text"])
     output = predict(data["text"])
     return jsonify(generated_text=output)
 
+def checkApiKey():
+    api_key = request.headers.get('x-api-key')
+    valid_api_keys = os.getenv('API_KEYS').split(',')
+    if api_key not in valid_api_keys:
+        os.abort(401)  # Unauthorized
+    
 
 if __name__ == '__main__':
     app.run(debug=True, host='0.0.0.0', port=5000)


### PR DESCRIPTION
Expose Panza as a FastAPI web server that can be launched via ./run_services.sh (HuggingFace backend) or via ./run_ollama_services.sh (Ollama backend).

Doing this as part of creating the gmail integration (chrome extension adds a button to the compose view that queries a locally hosted Panza server to easily ask Panza to write emails straight from Gmail). See https://github.com/shawseanyang/shawseanyang-panza-chrome-extension.

Credit to @ArmandNM for the original Flask code (switched to FastAPI) and for the suggestion to use FlaskAPI to prevent model reloading per request.

The web server requires requests to come with an API key header for security. API keys are stored in .env.